### PR TITLE
Removed unnecessary calls to getByAlias()

### DIFF
--- a/demo/app/src/mf2c/helloworld/IntersectionPoint.java
+++ b/demo/app/src/mf2c/helloworld/IntersectionPoint.java
@@ -47,13 +47,12 @@ public class IntersectionPoint {
 			PointCollection pcTemp = new PointCollection();
 			pcTemp.makePersistent(IntersectionResult.DATACLAY_ALIAS);
 			
-			calculateDistance(px, pcref, radius );
+			calculateDistance(px, pcref, radius, pcTemp );
 			
 			// only for COMPSs v1.4
 			COMPSs.waitForAllTasks();
 			
-			PointCollection pcres = PointCollection.getByAlias(IntersectionResult.DATACLAY_ALIAS);
-			System.out.println(pcres);
+			System.out.println(pcTemp);
 			
 			// Finish dataClay session
 			DataClay.finish();
@@ -71,7 +70,7 @@ public class IntersectionPoint {
 		}
 	}
 	
-	public static void calculateDistance(Point px, PointCollection pc, double radius)
+	public static void calculateDistance(Point px, PointCollection pc, double radius, PointCollection pcRes)
 	{
 		int[] points = new int[pc.getPoints().size()];
 
@@ -81,7 +80,6 @@ public class IntersectionPoint {
 			IntersectionImpl.calculate(px.getX(), px.getY(), p.getX(), p.getY(), radius, points, idx );
 		}
 		
-		PointCollection pcRes = PointCollection.getByAlias(IntersectionResult.DATACLAY_ALIAS);
 		System.out.println(pcRes);
 		
 		for( int idx = 0; idx < points.length; idx++ )


### PR DESCRIPTION
You don't need to call getByAlias every time you want to use an object. You can use object references as you usually do when objects are not persistent. You can see it in the code I edited. An alternative would be creating the collection normally inside calculateDistance and then make it persistent afterwards:
			PointCollection pcTemp = calculateDistance(px, pcref, radius);
			pcTemp.makePersistent(IntersectionResult.DATACLAY_ALIAS);